### PR TITLE
Optim: avoid useless require in http-client

### DIFF
--- a/lib/node-wrappers.ts
+++ b/lib/node-wrappers.ts
@@ -842,7 +842,8 @@ function _fixHttpClientOptions(options: HttpClientOptions) {
         },
         {} as http.IncomingHttpHeaders,
     );
-    opts.module = options.module || require(opts.protocol.substring(0, opts.protocol.length - 1));
+
+    opts.module = options.module || (opts.protocol === 'https:' ? https : http);
     if (opts.user != null) {
         // assumes basic auth for now
         let token = opts.user + ':' + (opts.password || '');
@@ -872,7 +873,7 @@ function _fixHttpClientOptions(options: HttpClientOptions) {
                 // https requests will be handled with CONNECT method
                 opts.isHttps = opts.protocol.substr(0, 5) === 'https';
                 if (opts.isHttps) {
-                    opts.proxy.module = require(opts.proxy.protocol.substring(0, opts.proxy.protocol.length - 1));
+                    opts.proxy.module = (opts.proxy.protocol === 'https:' ? https : http);
                     opts.proxy.headers = opts.proxy.headers || {};
                     opts.proxy.headers.host = opts.host;
                 } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "f-streams-async",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "f-streams-async",
-            "version": "3.3.0",
+            "version": "3.3.1",
             "license": "MIT",
             "dependencies": {
                 "f-promise-async": "^3.2.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "f-streams-async",
     "description": "node.js streams with promises",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "license": "MIT",
     "author": {
         "name": "Sébastien Berthier",


### PR DESCRIPTION
in _fixHttpClientOptions for http/https module

Sample after
```
_fixHttpClientOptions require took 0.015659987926483154 ms
_fixHttpClientOptions require took 0.013100028038024902 ms
_fixHttpClientOptions require took 0.012490034103393555 ms
_fixHttpClientOptions require took 0.011910021305084229 ms
_fixHttpClientOptions require took 0.012740015983581543 ms
_fixHttpClientOptions require took 0.01239001750946045 ms
_fixHttpClientOptions require took 0.011920034885406494 ms
_fixHttpClientOptions require took 0.0176999568939209 ms
_fixHttpClientOptions require took 0.012589991092681885 ms
_fixHttpClientOptions require took 0.013019979000091553 ms
_fixHttpClientOptions require took 0.01335996389389038 ms
_fixHttpClientOptions require took 0.012840032577514648 ms
```

Sample before
```
_fixHttpClientOptions require took 0.003979980945587158 ms
_fixHttpClientOptions require took 0.0013099908828735352 ms
_fixHttpClientOptions require took 0.001199960708618164 ms
_fixHttpClientOptions require took 0.0013200044631958008 ms
_fixHttpClientOptions require took 0.0012400150299072266 ms
_fixHttpClientOptions require took 0.0014399886131286621 ms
_fixHttpClientOptions require took 0.0014500021934509277 ms
_fixHttpClientOptions require took 0.001470029354095459 ms
_fixHttpClientOptions require took 0.0010899901390075684 ms
_fixHttpClientOptions require took 0.0010300278663635254 ms
_fixHttpClientOptions require took 0.0010800361633300781 ms
```

@tchambard 