### PR TITLE
Fix: node-wrappers avoid removeAllListeners

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1644,9 +1644,9 @@
             }
         },
         "node_modules/get-func-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-            "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
             "dev": true,
             "engines": {
                 "node": "*"
@@ -4605,9 +4605,9 @@
             "dev": true
         },
         "get-func-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-            "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
             "dev": true
         },
         "get-intrinsic": {

--- a/test/unit/node-wrappers-test.ts
+++ b/test/unit/node-wrappers-test.ts
@@ -1,0 +1,52 @@
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import { wait } from 'f-promise-async';
+import * as fs from 'fs';
+import { nodeReader, nodeWriter } from '../../lib';
+
+chai.use(chaiAsPromised);
+const assert = chai.assert;
+
+describe(module.id, () => {
+    let tmpDir: string;
+    let tmpFilePath: string;
+    before(async () => {
+        tmpDir = await wait(cb => fs.mkdtemp('/tmp/f-streams-test-', cb));
+        tmpFilePath = tmpDir + '/file.data';
+    });
+    after(async () => {
+        await wait(cb => fs.rmdir(tmpDir, cb));
+    });
+
+    it('node reader should not clear other listeners', async () => {
+        const fsStream = fs.createReadStream(__dirname + '/../../../test/fixtures/rss-sample.xml');
+        const reader = nodeReader<Buffer>(fsStream);
+        assert.lengthOf(fsStream.rawListeners('error'), 1);
+
+        const customErrorHandler = () => undefined;
+        fsStream.on('error', customErrorHandler);
+        assert.lengthOf(fsStream.rawListeners('error'), 2);
+        assert.include(fsStream.rawListeners('error'), customErrorHandler);
+
+        await reader.stop();
+
+        assert.lengthOf(fsStream.rawListeners('error'), 1);
+        assert.include(fsStream.rawListeners('error'), customErrorHandler);
+    });
+
+    it.skip('node writer should not clear other listeners', async () => {
+        const fsStream = fs.createWriteStream('/tmp/dont-care');
+        const writer = nodeWriter<Buffer>(fsStream);
+        assert.lengthOf(fsStream.rawListeners('error'), 1);
+
+        const customErrorHandler = () => undefined;
+        fsStream.on('error', customErrorHandler);
+        assert.lengthOf(fsStream.rawListeners('error'), 2);
+        assert.include(fsStream.rawListeners('error'), customErrorHandler);
+
+        await writer.stop();
+
+        assert.lengthOf(fsStream.rawListeners('error'), 1);
+        assert.include(fsStream.rawListeners('error'), customErrorHandler);
+    });
+});


### PR DESCRIPTION
- register all listeners with custom method _emitterOn
- allow other components to listen event emitter (ex grpc call)
- skip node-writer tests (see https://github.com/BEE-BUZZINESS/f-streams-async/pull/10)

@tchambard 