### PR TITLE
Fix: node-wrappers writer stop close stream (bis)

### DIFF
--- a/lib/node-wrappers.ts
+++ b/lib/node-wrappers.ts
@@ -180,6 +180,7 @@ export class ReadableStream<EmitterT extends NodeJS.ReadableStream> extends Wrap
 
         this._autoClosed.push(() => {
             if (!this._done) this._onData(new Error('stream was closed unexpectedly'));
+            this.unwrap();
         });
         this.reader = generic.reader(this._readChunk.bind(this), this.stop.bind(this));
     }
@@ -362,7 +363,8 @@ export class WritableStream<EmitterT extends NodeJS.WritableStream> extends Wrap
         this._autoClosed.push(() => {
             const err = new Error('stream was closed unexpectedly');
             if (this._onDrain) this._onDrain(err);
-            else this._error = err;
+            else this._error = err; 
+            this.unwrap();       
         });
         this.writer = generic.writer(async (data?: Data) => {
             // emitter has been closed before writer end, consider this as normal
@@ -378,7 +380,7 @@ export class WritableStream<EmitterT extends NodeJS.WritableStream> extends Wrap
                 //
                 if (!this._emitter.write(data)) await this._drain();
             } else {
-                await this.stop();
+                await wait(cb => this._emitter.end.call(this._emitter, cb));
             }
             return this.writer;
         }, this.stop.bind(this));
@@ -435,7 +437,6 @@ export class WritableStream<EmitterT extends NodeJS.WritableStream> extends Wrap
         if (arg && arg !== true) this._error = this._error || arg;
         if (!this.closed) {
             await wait(cb => this._emitter.end.call(this._emitter, cb));
-            this.unwrap();
         }
     }
 

--- a/lib/node-wrappers.ts
+++ b/lib/node-wrappers.ts
@@ -378,10 +378,10 @@ export class WritableStream<EmitterT extends NodeJS.WritableStream> extends Wrap
                 //
                 if (!this._emitter.write(data)) await this._drain();
             } else {
-                await wait(cb => this._emitter.end.call(this._emitter, cb));
+                await this.stop();
             }
             return this.writer;
-        });
+        }, this.stop.bind(this));
     }
 
     async _drain() {
@@ -429,6 +429,14 @@ export class WritableStream<EmitterT extends NodeJS.WritableStream> extends Wrap
             });
         }
         return this;
+    }
+
+    async stop(arg?: any) {
+        if (arg && arg !== true) this._error = this._error || arg;
+        if (!this.closed) {
+            await wait(cb => this._emitter.end.call(this._emitter, cb));
+            this.unwrap();
+        }
     }
 
     get events() {

--- a/test/unit/http-test.ts
+++ b/test/unit/http-test.ts
@@ -8,7 +8,7 @@ const { equal, ok, strictEqual, deepEqual } = assert;
 let server: HttpServer;
 
 describe(module.id, () => {
-    before(() => {
+    before(async () => {
         server = httpServer(async function (req, res) {
             if (req.method === 'POST') {
                 const text = await req.readAll();
@@ -29,6 +29,7 @@ describe(module.id, () => {
                 res.end('reply for GET');
             }
         });
+        await server.listen(3004);
     });
 
     after(async () => {
@@ -45,7 +46,6 @@ describe(module.id, () => {
                 'POST result ok for ' + type,
             );
         }
-        await server.listen(3004);
         await _test('text/plain', 'post test');
         await _test('application/json', { test: 'post test' });
         await _test('text/html', '<!DOCTYPE html>');

--- a/test/unit/node-wrappers-test.ts
+++ b/test/unit/node-wrappers-test.ts
@@ -1,78 +1,157 @@
 import * as chai from 'chai';
+import * as path from 'path';
 import * as chaiAsPromised from 'chai-as-promised';
-import { wait } from 'f-promise-async';
+import { sleep, wait } from 'f-promise-async';
 import { lsof } from 'list-open-files';
 import * as fs from 'fs';
 import { nodeReader, nodeWriter } from '../../lib';
+import { Readable, Writable } from 'stream';
 
 chai.use(chaiAsPromised);
 const assert = chai.assert;
 
 describe(module.id, () => {
-    let tmpDir: string;
-    let tmpFilePath: string;
-    before(async () => {
-        tmpDir = await wait(cb => fs.mkdtemp('/tmp/f-streams-test-', cb));
-        tmpFilePath = tmpDir + '/file.data';
-    });
-    after(async () => {
-        await wait(cb => fs.unlink(tmpFilePath, cb));
-        await wait(cb => fs.rmdir(tmpDir, cb));
-    });
-
-    it('node reader should not clear other listeners', async () => {
-        const fsStream = fs.createReadStream(__dirname + '/../../../test/fixtures/rss-sample.xml');
-        const reader = nodeReader<Buffer>(fsStream);
-        assert.lengthOf(fsStream.rawListeners('error'), 1);
+    async function assertOtherEventListener(emitter: Writable | Readable, action: () => Promise<void>) {
+        assert.lengthOf(emitter.rawListeners('error'), 1);
 
         const customErrorHandler = () => undefined;
-        fsStream.on('error', customErrorHandler);
-        assert.lengthOf(fsStream.rawListeners('error'), 2);
-        assert.include(fsStream.rawListeners('error'), customErrorHandler);
+        emitter.on('error', customErrorHandler);
+        assert.lengthOf(emitter.rawListeners('error'), 2);
+        assert.include(emitter.rawListeners('error'), customErrorHandler);
 
-        await reader.stop();
+        await action();
+        await sleep(10);
 
-        assert.lengthOf(fsStream.rawListeners('error'), 1);
-        assert.include(fsStream.rawListeners('error'), customErrorHandler);
-    });
-
-    it('node writer end should not clear other listeners', async () => {
-        const fsStream = fs.createWriteStream(tmpFilePath);
-        const writer = nodeWriter<Buffer>(fsStream);
-        assert.lengthOf(fsStream.rawListeners('error'), 1);
-
-        const customErrorHandler = () => undefined;
-        fsStream.on('error', customErrorHandler);
-        assert.lengthOf(fsStream.rawListeners('error'), 2);
-        assert.include(fsStream.rawListeners('error'), customErrorHandler);
-
-        await writer.write(undefined);
-        await assertTmpFileNotOpen();
-
-        assert.lengthOf(fsStream.rawListeners('error'), 1);
-        assert.include(fsStream.rawListeners('error'), customErrorHandler);
-    });
-
-    it('node writer stop should not clear other listeners', async () => {
-        const fsStream = fs.createWriteStream(tmpFilePath);
-        const writer = nodeWriter<Buffer>(fsStream);
-        assert.lengthOf(fsStream.rawListeners('error'), 1);
-
-        const customErrorHandler = () => undefined;
-        fsStream.on('error', customErrorHandler);
-        assert.lengthOf(fsStream.rawListeners('error'), 2);
-        assert.include(fsStream.rawListeners('error'), customErrorHandler);
-
-        await writer.stop();
-        await assertTmpFileNotOpen();
-
-        assert.lengthOf(fsStream.rawListeners('error'), 1);
-        assert.include(fsStream.rawListeners('error'), customErrorHandler);
-    });
-
-    async function assertTmpFileNotOpen() {
-        const openFiles = (await lsof())[0].files;
-        const tmpFileOpen = openFiles.find(file => file.name === tmpFilePath);
-        assert.isUndefined(tmpFileOpen, `Temporary file ${tmpFilePath} is still open`);
+        assert.lengthOf(emitter.rawListeners('error'), 1);
+        assert.include(emitter.rawListeners('error'), customErrorHandler);
+        assert.isTrue(emitter.closed);
     }
+
+    describe('fs node stream', () => {
+        let tmpDir: string;
+        let tmpFilePath: string;
+        const existingFilePath = path.resolve(__dirname + '/../../../test/fixtures/rss-sample.xml');
+        before(async () => {
+            tmpDir = await wait(cb => fs.mkdtemp('/tmp/f-streams-test-', cb));
+            tmpFilePath = tmpDir + '/file.data';
+        });
+        after(async () => {
+            await wait(cb => fs.unlink(tmpFilePath, cb)).catch(() => undefined);
+            await wait(cb => fs.rmdir(tmpDir, cb));
+        });
+
+        it('node reader end should not clear other listeners', async () => {
+            const fsStream = fs.createReadStream(existingFilePath);
+            const reader = nodeReader<Buffer>(fsStream);
+    
+            await assertOtherEventListener(fsStream, async () => {
+                await reader.readAll();
+            });
+            await assertFileNotOpen(existingFilePath);
+        });
+    
+        it('node reader stop should not clear other listeners', async () => {
+            const fsStream = fs.createReadStream(existingFilePath);
+            const reader = nodeReader<Buffer>(fsStream);
+    
+            await assertOtherEventListener(fsStream, async () => {
+                await reader.stop();
+            });
+            await assertFileNotOpen(existingFilePath);
+        });
+    
+        it('node writer end should not clear other listeners', async () => {
+            const fsStream = fs.createWriteStream(tmpFilePath);
+            const writer = nodeWriter<Buffer>(fsStream);
+    
+            await assertOtherEventListener(fsStream, async () => {
+                await writer.write(undefined);
+            });
+            await assertFileNotOpen(existingFilePath);
+        });
+    
+        it('node writer stop should not clear other listeners', async () => {
+            const fsStream = fs.createWriteStream(tmpFilePath);
+            const writer = nodeWriter<Buffer>(fsStream);
+    
+            await assertOtherEventListener(fsStream, async () => {
+                await writer.stop();
+            });
+            await assertFileNotOpen(existingFilePath);
+        });
+
+        async function assertFileNotOpen(filename: string) {
+            const openFiles = (await lsof())[0].files;
+            const tmpFileOpen = openFiles.find(file => file.name === filename);
+            assert.isUndefined(tmpFileOpen, `Temporary file ${filename} is still open`);
+        }
+    });
+    
+    describe('custom node stream', () => {
+
+        it('node writer stop should not clear other listeners', async () => {
+            const numberConsumeStream = new Writable({
+                write(chunk: Buffer, encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+                    callback();
+                },
+            });
+            const writer = nodeWriter<Buffer>(numberConsumeStream);
+
+            await assertOtherEventListener(numberConsumeStream, async () => {
+                await writer.stop();
+            });
+        });
+
+        it('node writer error should not clear other listeners', async () => {
+            const numberConsumeStream = new Writable({
+                write(chunk: Buffer, encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+                    callback(new Error('hello'));
+                },
+            });
+            const writer = nodeWriter<Buffer>(numberConsumeStream);
+
+            await assertOtherEventListener(numberConsumeStream, async () => {
+                await writer.write(Buffer.alloc(12)).catch(e => console.log(`write error: ${e.message}`));
+            });
+        });
+
+        it('node reader end should not clear other listeners', async () => {
+            const numberConsumeStream = new Readable({
+                read(size?: number) {
+                    this.push(null);
+                },
+            });
+            const reader = nodeReader<number>(numberConsumeStream);
+
+            await assertOtherEventListener(numberConsumeStream, async () => {
+                await reader.readAll();
+            });
+        });
+
+        it('node reader stop should not clear other listeners', async () => {
+            const numberConsumeStream = new Readable({
+                read(size?: number) {
+                    this.push(null);
+                },
+            });
+            const reader = nodeReader<number>(numberConsumeStream);
+
+            await assertOtherEventListener(numberConsumeStream, async () => {
+                await reader.stop();
+            });
+        });
+
+        it('node reader error should not clear other listeners', async () => {
+            const numberConsumeStream = new Readable({
+                read(size?: number) {
+                    this.destroy(new Error('hello'));
+                },
+            });
+            const reader = nodeReader<number>(numberConsumeStream);
+
+            await assertOtherEventListener(numberConsumeStream, async () => {
+                await reader.readAll().catch(e => console.log(`read error: ${e.message}`));
+            });
+        });
+    });
 });

--- a/test/unit/node-wrappers-test.ts
+++ b/test/unit/node-wrappers-test.ts
@@ -1,6 +1,7 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import { wait } from 'f-promise-async';
+import { lsof } from 'list-open-files';
 import * as fs from 'fs';
 import { nodeReader, nodeWriter } from '../../lib';
 
@@ -15,6 +16,7 @@ describe(module.id, () => {
         tmpFilePath = tmpDir + '/file.data';
     });
     after(async () => {
+        await wait(cb => fs.unlink(tmpFilePath, cb));
         await wait(cb => fs.rmdir(tmpDir, cb));
     });
 
@@ -34,8 +36,25 @@ describe(module.id, () => {
         assert.include(fsStream.rawListeners('error'), customErrorHandler);
     });
 
-    it.skip('node writer should not clear other listeners', async () => {
-        const fsStream = fs.createWriteStream('/tmp/dont-care');
+    it('node writer end should not clear other listeners', async () => {
+        const fsStream = fs.createWriteStream(tmpFilePath);
+        const writer = nodeWriter<Buffer>(fsStream);
+        assert.lengthOf(fsStream.rawListeners('error'), 1);
+
+        const customErrorHandler = () => undefined;
+        fsStream.on('error', customErrorHandler);
+        assert.lengthOf(fsStream.rawListeners('error'), 2);
+        assert.include(fsStream.rawListeners('error'), customErrorHandler);
+
+        await writer.write(undefined);
+        await assertTmpFileNotOpen();
+
+        assert.lengthOf(fsStream.rawListeners('error'), 1);
+        assert.include(fsStream.rawListeners('error'), customErrorHandler);
+    });
+
+    it('node writer stop should not clear other listeners', async () => {
+        const fsStream = fs.createWriteStream(tmpFilePath);
         const writer = nodeWriter<Buffer>(fsStream);
         assert.lengthOf(fsStream.rawListeners('error'), 1);
 
@@ -45,8 +64,15 @@ describe(module.id, () => {
         assert.include(fsStream.rawListeners('error'), customErrorHandler);
 
         await writer.stop();
+        await assertTmpFileNotOpen();
 
         assert.lengthOf(fsStream.rawListeners('error'), 1);
         assert.include(fsStream.rawListeners('error'), customErrorHandler);
     });
+
+    async function assertTmpFileNotOpen() {
+        const openFiles = (await lsof())[0].files;
+        const tmpFileOpen = openFiles.find(file => file.name === tmpFilePath);
+        assert.isUndefined(tmpFileOpen, `Temporary file ${tmpFilePath} is still open`);
+    }
 });


### PR DESCRIPTION
- retry after revert of [bc8a3b60f11a3e2a6a14fbee6a3cab839d0fbe89](https://github.com/BEE-BUZZINESS/f-streams-async/pull/10)
- stop at  write.end()
- call unwrap to close wrapper and remove listeners
- do not destroy stream on stop (pb with http request (cpos stuck getMediaInfoFromUrl), do reproduced in unit-tests !)

@tchambard 